### PR TITLE
Fixed NullReferenceException on missing opcode arguments (i.e. "IFE [foo], ")

### DIFF
--- a/Organic/Assembler.cs
+++ b/Organic/Assembler.cs
@@ -591,16 +591,21 @@ namespace Organic
                     }
                     else
                     {
+                        if (opcode.valueA == null || (!nonBasic && opcode.valueB == null))
+                        {
+                            listEntry.ErrorCode = ErrorCode.InsufficientParamters;
+                            output.Add(listEntry);
+                            continue;
+                        }
+
                         listEntry.Opcode = opcode;
                         StringMatch valueA = null, valueB = null;
                         listEntry.Output = new ushort[1];
                         if (!nonBasic)
                         {
                             listEntry.CodeType = CodeType.BasicInstruction;
-                            if (opcode.valueA != null)
-                                valueA = MatchString(opcode.valueA, ValueTable);
-                            if (opcode.valueB != null)
-                                valueB = MatchString(opcode.valueB, ValueTable);
+                            valueA = MatchString(opcode.valueA, ValueTable);
+                            valueB = MatchString(opcode.valueB, ValueTable);
                             if (valueA.value == valueB.value && valueA.value != 0x1E && valueB.value != 0x1E)
                                 listEntry.WarningCode = WarningCode.RedundantStatement;
                             if (valueB.value == 0x1F && !opcode.match.Contains("IF"))
@@ -634,8 +639,7 @@ namespace Organic
                         else
                         {
                             listEntry.CodeType = CodeType.NonBasicInstruction;
-                            if (opcode.valueA != null)
-                                valueA = MatchString(opcode.valueA, ValueTable);
+                            valueA = MatchString(opcode.valueA, ValueTable);
                             listEntry.ValueA = valueA;
                             // De-localize labels
                             if (listEntry.ValueA.isLiteral)

--- a/Organic/Directives.cs
+++ b/Organic/Directives.cs
@@ -404,7 +404,7 @@ namespace Organic
                                 currentAddress += (ushort)padding.Length;
                         }
                     }
-                    else if (parameters.Length == 1)
+                    else if (parameters.Length < 3)
                         output.Add(new ListEntry(line, FileNames.Peek(), LineNumbers.Peek(), currentAddress, ErrorCode.InsufficientParamters));
                     else
                         output.Add(new ListEntry(line, FileNames.Peek(), LineNumbers.Peek(), currentAddress, ErrorCode.TooManyParamters));


### PR DESCRIPTION
Current version of Organic throws NullReferenceException when trying to assemble a line like `IFE [foo], `. This pull request causes it to emit an InsufficientParameters error instead.